### PR TITLE
Fix blog posts sorting

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -43,7 +43,7 @@ exports.createSchemaCustomization = ({ actions }) => {
     type Frontmatter {
       category: [Category]
       author: String
-      date: Date @dateformat(formatString: "DD/MM/YYYY")
+      date: Date @dateformat
     }
     type Category {
       label: String


### PR DESCRIPTION
Removes the date format on the schema customization to fix the date sorting on the blog page

Signed-off-by: Tomás Castillo <tcastilloboireau@gmail.com>