### PR TITLE
Linkedin insight site tag

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -210,6 +210,16 @@ module.exports = {
         htmlTitle: `Open Infrastructure Foundation | Content Manager`,
         includeRobots: false,
       }
+    },
+    {
+      resolve: 'gatsby-plugin-linkedin-insight',
+      options: {
+        partnerId: '2906612',
+  
+        // Include LinkedIn Insight in development.
+        // Defaults to false meaning LinkedIn Insight will only be loaded in production.
+        includeInDevelopment: true
+      }
     }
   ],
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "gatsby-plugin-feed": "^3.4.0",
     "gatsby-plugin-google-analytics": "^2.10.0",
     "gatsby-plugin-google-gtag": "^2.7.0",
+    "gatsby-plugin-linkedin-insight": "^1.0.1",
     "gatsby-plugin-manifest": "^2.3.3",
     "gatsby-plugin-netlify": "^2.2.1",
     "gatsby-plugin-netlify-cms": "^4.3.13",


### PR DESCRIPTION
Linkedin insight global site tag was configured using the gatsby-plugin-linkedin-insight plugin