### PR TITLE
Fix title color in blue box

### DIFF
--- a/src/style/modules/_projects.scss
+++ b/src/style/modules/_projects.scss
@@ -283,7 +283,7 @@
     max-width: 850px;
   }
 
-  .itemtitle {
+  h3.itemtitle {
     font-family: "Jura", "Roboto", sans-serif;
     color: #28a4db;
     margin-top: 20px;
@@ -291,6 +291,16 @@
     font-size: 2rem;
     text-transform: uppercase;
   }
+
+  h4.itemtitle {
+    font-family: "Jura", "Roboto", sans-serif;
+    color: white;
+    margin-top: 20px;
+    margin-bottom: 10px;
+    font-size: 2rem;
+    text-transform: uppercase;
+  }
+
 
   .fix-h5 {
     color: white;

--- a/yarn.lock
+++ b/yarn.lock
@@ -8630,6 +8630,13 @@ gatsby-plugin-google-gtag@^2.7.0:
     "@babel/runtime" "^7.12.5"
     minimatch "^3.0.4"
 
+gatsby-plugin-linkedin-insight@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-linkedin-insight/-/gatsby-plugin-linkedin-insight-1.0.1.tgz#93531b7f19675c83115eca05c5cfc49d880288f3"
+  integrity sha512-CjY1yUT0pv7ueD539SbdpQI2PIdrrpX7W+mfk9JnKYoURcBFP044GFaryuIgHqNTsi4X7CwO0YkF41i1j7SAqg==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+
 gatsby-plugin-manifest@^2.3.3:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/gatsby-plugin-manifest/-/gatsby-plugin-manifest-2.4.1.tgz#57381d3cc2d3b8aaa0d40bfcb7595323490f8708"


### PR DESCRIPTION
Signed-off-by: James Cole <james@openstack.org>

Changes h4.itemtitle font color to white so it shows up in the blue boxes titled "Interested in contributing to the Four Opens?" and "Interested in hosting your project with OpenInfra Foundation?". The section titles are currently the same as the background color. 