### PR TITLE
Removes startup price for platinum tier

### DIFF
--- a/src/templates/members-page.js
+++ b/src/templates/members-page.js
@@ -226,7 +226,6 @@ export const MembersPageTemplate = ({
                                     <span className="price">{memberBenefits.fees.platinum.price}</span>
                                     <span className="fee">Annual Membership Fee</span>
                                     <LinkComponent href={memberBenefits.fees.platinum.button.link} >{memberBenefits.fees.platinum.button.text}</LinkComponent>
-                                    <span>Startup pricing available</span>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
* Removes the 'Startup pricing available' text at the membership benefits on mobile

Signed-off-by: Tomás Castillo <tcastilloboireau@gmail.com>