### PR TITLE
Ignore check for image extensions

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -96,7 +96,12 @@ module.exports = {
       },
     },
     'gatsby-plugin-sharp',
-    'gatsby-transformer-sharp',
+    {
+      resolve: `gatsby-transformer-sharp`,
+      options: {
+        checkSupportedExtensions: false,
+      },
+    },
     {
       resolve: 'gatsby-transformer-remark',
       options: {


### PR DESCRIPTION
* Removes warnings for image plugin on log at build and deploy

Signed-off-by: Tomás Castillo <tcastilloboireau@gmail.com>