### PR TITLE
Change required fields for about pages

### DIFF
--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -258,8 +258,8 @@ collections:
           {label: "Image", name: "image", widget: image},
           {label: "Twitter Username", name: "twitterUsername", widget: string},
         ]}
-      - {label: "Title", name: title, widget: string}
-      - {label: "Sub Title", name: subTitle, widget: string}
+      - {label: "Title", name: title, widget: string, required: false}
+      - {label: "Sub Title", name: subTitle, widget: string, required: false}
       - {label: "Body", name: body, widget: markdown}
       - {label: "Footer", name: footer, widget: object, required: false, fields: [
           {label: "Title", name: title, widget: string, required: false },


### PR DESCRIPTION
* Remove the required fields for title and subtitle on about pages

ref: https://tipit.avaza.com/project/view#!tab=task-pane&groupby=MyTaskDueDate&view=vertical&task=2802449&fileview=grid

Signed-off-by: Tomás Castillo <tcastilloboireau@gmail.com>