### PR TITLE
fix: makes SummitCard link at card level only when link prop provided

### DIFF
--- a/src/components/LinkComponent.js
+++ b/src/components/LinkComponent.js
@@ -1,37 +1,45 @@
-import React from 'react'
-import PropTypes from "prop-types"
-import { Link } from 'gatsby'
-import { OutboundLink } from 'gatsby-plugin-google-analytics'
+import * as React from "react";
+import PropTypes from "prop-types";
+import { Link } from "gatsby";
+import { OutboundLink } from "gatsby-plugin-google-analytics";
 
-const LinkComponent = class extends React.Component {
-  render() {
-
-    let { href, children, className, id, ...rest } = this.props;
-
-    if(href.match(/^(http:\/\/|https:\/\/|www\.)/)){
-      return (
-        <OutboundLink href={href} id={id} className={className} target="_blank" rel="noopener noreferrer" {...rest}>
-          {children}
-        </OutboundLink>
-      )
-    } else if (href.match(/mailto:/)){
-      return (
-        <a href={href} id={id} className={className} {...rest}>
-          {children}
-        </a>
-      )
-    } else {
-      return (
-        <Link to={href} id={id} className={className} {...rest}>
-          {children}
-        </Link>
-      )
-    }    
+const LinkComponent = ({ href, children, ...rest }) => {
+  if (!href) {
+    // render children directly if no href is provided
+    return <>{children}</>;
   }
-}
+
+  if (/^(http:\/\/|https:\/\/|www\.)/.test(href)) {
+    return (
+      <OutboundLink
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+        {...rest}
+      >
+        {children}
+      </OutboundLink>
+    );
+  }
+
+  if (/mailto:/.test(href)) {
+    return (
+      <a href={href} {...rest}>
+        {children}
+      </a>
+    );
+  }
+
+  return (
+    <Link to={href} {...rest}>
+      {children}
+    </Link>
+  );
+};
 
 LinkComponent.propTypes = {
-  href: PropTypes.string.isRequired  
-}
+  href: PropTypes.string,
+  children: PropTypes.node.isRequired
+};
 
-export default LinkComponent
+export default LinkComponent;

--- a/src/components/PastSummits/index.jsx
+++ b/src/components/PastSummits/index.jsx
@@ -10,6 +10,7 @@ const PAST_SUMMITS = [
     background: "/img/summit-landing/cards/summit-asia.png",
     date: "September 3 & 4, 2024",
     location: "Suwon Convention Center, Suwon, South Korea",
+    link: "https://youtube.com/playlist?list=PLKqaoAnDyfgqjY-vzt45oayXLa4aLpMRU&feature=shared",
     notification: {
       text: " ",
       button: {
@@ -36,6 +37,7 @@ const PastSummits = ({ title }) => {
         <SummitCard
           key={summit.key}
           background={summit.background}
+          link={summit.link}
           summit={summit}
         />
       ))}

--- a/src/components/SummitCard/index.jsx
+++ b/src/components/SummitCard/index.jsx
@@ -11,7 +11,7 @@ const SummitCard = ({
   background,
   summit,
   cardStyles,
-  link = "https://summit2025.openinfra.org",
+  link
 }) => {
   if (!summit) return null;
 

--- a/src/components/UpcomingSummits/index.jsx
+++ b/src/components/UpcomingSummits/index.jsx
@@ -10,6 +10,7 @@ const UPCOMING_SUMMITS = [
     background: "/img/summit-landing/cards/summit-europe-25-2.png",
     date: "October 17-19, 2025",
     location: "École Polytechnique, Paris-Saclay, France",
+    link: "https://summit2025.openinfra.org",
     notification: {
       text: " ",
       button: {
@@ -36,6 +37,7 @@ const UpcomingSummits = ({ title }) => {
         <SummitCard
           key={summit.key}
           background={summit.background}
+          link={summit.link}
           summit={summit}
         />
       ))}


### PR DESCRIPTION
This PR fixes and ongoing bug caused by a default link prop value at SummitCard, which caused all component instances that where not provided that link prop, all link to default value.
Also, modifies LinkComponent to not render a link wrapper when no href prop provided to it; now it just render the provided children. 