### PR TITLE
[Task 3848895] Member Data Lookup Issue

### DIFF
--- a/src/actions/member-actions.js
+++ b/src/actions/member-actions.js
@@ -3,6 +3,7 @@ import {
   createAction,
   escapeFilterValue
 } from "openstack-uicore-foundation/lib/utils/actions";
+import { MEMBERSHIP_TYPE_INDIVIDUAL } from "./user-actions";
 
 export const GET_MEMBERS = 'GET_MEMBERS';
 export const GET_MEMBERS_SUCCESS = 'GET_MEMBERS_SUCCESS';
@@ -16,7 +17,7 @@ export const GET_ELECTION_MEMBER_PROFILE_ERROR = 'GET_ELECTION_MEMBER_PROFILE_ER
 
 export const getMembers = (keyword, letter, page = 1) => (dispatch, getState) => {
 
-  const filter = ['active==1', 'membership_type==Individual'];
+  const filter = ['active==1', `membership_type==${MEMBERSHIP_TYPE_INDIVIDUAL}`];
 
   if (keyword) {
     const escapedKeyword = escapeFilterValue(keyword);


### PR DESCRIPTION
## Summary

#### Original request:
This query returns a record with "id":162837 https://openstackid-resources.openstack.org/api/public/v1/members?expand=groups%2Call_affiliations%2Call_affiliations.organization&filter%5B%5D=email%3D%3Dlazekteam%40gmail.com&filter%5B%5D=membership_type%3D%3DIndividual&relations=affiliations%2Cgroups

but https://www.openstack.org/community/members/profile/162837 returns a 404 page

#### Technical request
Change member filtering from GroupID `5` to MembershipType `Individual`.

## Changes
Filter  in members actions `getMembers` function. from `group_slug==foundation-members` to `membership_type==Individual`

## Testing
<!--
- Explain how you tested the changes.
- Mention any relevant test cases or manual steps.
-->
## Related Issues
- https://tipit.avaza.com/task#task=3848895

## Notes
This PR is related with this other PR: https://github.com/OpenStackweb/openstack-org/pull/392