### PR TITLE
Simple header nav

### DIFF
--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -21,12 +21,25 @@ const Navbar = class extends React.Component {
     super(props)
     this.state = {
       active: false,
-      navBarActiveClass: ''
+      navBarActiveClass: '',
+      expandedIndex: null
     }
 
     this.onClickLogin = this.onClickLogin.bind(this);
     this.onClickLogout = this.onClickLogout.bind(this);
     this.getBackURL = this.getBackURL.bind(this);
+  }
+
+  isMobile() {
+    return typeof window !== 'undefined' && window.innerWidth <= 768;
+  }
+
+  onClickDropdownTrigger = (evt, index) => {
+    if (!this.isMobile()) return;
+    evt.preventDefault();
+    this.setState((prevState) => ({
+      expandedIndex: prevState.expandedIndex === index ? null : index
+    }));
   }
 
   getBackURL() {
@@ -87,20 +100,23 @@ const Navbar = class extends React.Component {
               <ul className="nav-menu menu-item">
                 {Menu.nav.map((li, index) => {
                   if(li.display) {
+                    const isExpanded = this.state.expandedIndex === index;
                     return (
                       <li key={index}>
-                        <div className="dropdown is-hoverable">
+                        <div className={`dropdown is-hoverable ${isExpanded ? 'is-active' : ''}`}>
                           <div className="dropdown-trigger">
                             { li.url &&
-                                  <button aria-haspopup="true" aria-controls="dropdown-menu" className="button">
+                                  <button aria-haspopup="true" aria-controls="dropdown-menu" aria-expanded={isExpanded} className="button" onClick={(evt) => this.onClickDropdownTrigger(evt, index)}>
                                     <LinkComponent href={li.url}>
                                       <span>{li.title}</span>
                                     </LinkComponent>
+                                    <span className="navbar-dropdown-arrow" aria-hidden="true">{isExpanded ? '▲' : '▼'}</span>
                                   </button>
                             }
-                            { !li.url &&                              
-                                <button aria-haspopup="true" aria-controls="dropdown-menu" className="button">
+                            { !li.url &&
+                                <button aria-haspopup="true" aria-controls="dropdown-menu" aria-expanded={isExpanded} className="button" onClick={(evt) => this.onClickDropdownTrigger(evt, index)}>
                                   <span>{li.title}</span>
+                                  <span className="navbar-dropdown-arrow" aria-hidden="true">{isExpanded ? '▲' : '▼'}</span>
                                 </button>
                             }
                           </div>

--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -6,6 +6,16 @@ import {doLogin, initLogOut} from 'openstack-uicore-foundation/lib/security/meth
 import PropTypes from "prop-types";
 import URI from "urijs"
 
+const LINKS_PER_COLUMN = 4;
+
+const chunkLinks = (links) => {
+  const columns = [];
+  for (let i = 0; i < links.length; i += LINKS_PER_COLUMN) {
+    columns.push(links.slice(i, i + LINKS_PER_COLUMN));
+  }
+  return columns;
+};
+
 const Navbar = class extends React.Component {
   constructor(props) {
     super(props)
@@ -96,15 +106,17 @@ const Navbar = class extends React.Component {
                           </div>
                           <div id="dropdown-menu" role="menu" className="dropdown-menu">
                             <div className="dropdown-content">
-                              {li.links.map((link, index) => {
-                                return (
-                                  <div className="menuitemeffect" key={index}>
-                                    <LinkComponent href={link.url} className="dropdown-item">
-                                      <span>{link.text} </span>
-                                    </LinkComponent>
-                                  </div>
-                                )
-                              })}
+                              {chunkLinks(li.links).map((column, colIndex) => (
+                                <div className="dropdown-column" key={colIndex}>
+                                  {column.map((link, index) => (
+                                    <div className="menuitemeffect" key={index}>
+                                      <LinkComponent href={link.url} className="dropdown-item">
+                                        <span>{link.text} </span>
+                                      </LinkComponent>
+                                    </div>
+                                  ))}
+                                </div>
+                              ))}
                             </div>
                           </div>
                         </div>

--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -96,9 +96,6 @@ const Navbar = class extends React.Component {
                           </div>
                           <div id="dropdown-menu" role="menu" className="dropdown-menu">
                             <div className="dropdown-content">
-                              <div className="nested-menu-image">
-                                <img src={li.image} alt="" style={li.marginLeft ? { marginLeft: li.marginLeft } : {}} />
-                              </div>
                               {li.links.map((link, index) => {
                                 return (
                                   <div className="menuitemeffect" key={index}>

--- a/src/components/NavbarV2.js
+++ b/src/components/NavbarV2.js
@@ -20,12 +20,25 @@ const NavbarV2 = class extends React.Component {
     super(props)
     this.state = {
       active: false,
-      navBarActiveClass: ''
+      navBarActiveClass: '',
+      expandedIndex: null
     }
 
     this.onClickLogin = this.onClickLogin.bind(this);
     this.onClickLogout = this.onClickLogout.bind(this);
     this.getBackURL = this.getBackURL.bind(this);
+  }
+
+  isMobile() {
+    return typeof window !== 'undefined' && window.innerWidth <= 768;
+  }
+
+  onClickDropdownTrigger = (evt, index) => {
+    if (!this.isMobile()) return;
+    evt.preventDefault();
+    this.setState((prevState) => ({
+      expandedIndex: prevState.expandedIndex === index ? null : index
+    }));
   }
 
   getBackURL() {
@@ -89,20 +102,23 @@ const NavbarV2 = class extends React.Component {
               <ul className="nav-menu menu-item">
                 {Menu.nav.map((li, index) => {
                   if(li.display) {
+                    const isExpanded = this.state.expandedIndex === index;
                     return (
                       <li className="navbar-item-v2 navbar-item-v2-dropdown" key={index}>
-                        <div className="dropdown is-hoverable">
+                        <div className={`dropdown is-hoverable ${isExpanded ? 'is-active' : ''}`}>
                           <div className="dropdown-trigger">
                             { li.url &&
-                                  <button aria-haspopup="true" aria-controls="dropdown-menu" className="button navbar-dropdown-btn-v2">
+                                  <button aria-haspopup="true" aria-controls="dropdown-menu" aria-expanded={isExpanded} className="button navbar-dropdown-btn-v2" onClick={(evt) => this.onClickDropdownTrigger(evt, index)}>
                                     <a href={li.url}>
                                       <span>{li.title}</span>
                                     </a>
+                                    <span className="navbar-dropdown-arrow" aria-hidden="true">{isExpanded ? '▲' : '▼'}</span>
                                   </button>
                             }
-                            { !li.url &&                              
-                                <button aria-haspopup="true" aria-controls="dropdown-menu" className="button navbar-dropdown-btn-v2">
+                            { !li.url &&
+                                <button aria-haspopup="true" aria-controls="dropdown-menu" aria-expanded={isExpanded} className="button navbar-dropdown-btn-v2" onClick={(evt) => this.onClickDropdownTrigger(evt, index)}>
                                   <span>{li.title}</span>
+                                  <span className="navbar-dropdown-arrow" aria-hidden="true">{isExpanded ? '▲' : '▼'}</span>
                                 </button>
                             }
                           </div>

--- a/src/components/NavbarV2.js
+++ b/src/components/NavbarV2.js
@@ -5,6 +5,16 @@ import {doLogin, initLogOut} from 'openstack-uicore-foundation/lib/security/meth
 import PropTypes from "prop-types";
 import URI from "urijs"
 
+const LINKS_PER_COLUMN = 4;
+
+const chunkLinks = (links) => {
+  const columns = [];
+  for (let i = 0; i < links.length; i += LINKS_PER_COLUMN) {
+    columns.push(links.slice(i, i + LINKS_PER_COLUMN));
+  }
+  return columns;
+};
+
 const NavbarV2 = class extends React.Component {
   constructor(props) {
     super(props)
@@ -98,15 +108,17 @@ const NavbarV2 = class extends React.Component {
                           </div>
                           <div id="dropdown-menu" role="menu" className="dropdown-menu">
                             <div className="dropdown-content">
-                              {li.links.map((link, index) => {
-                                return (
-                                  <div className="menuitemeffect" key={index}>
-                                    <a href={link.url} className="dropdown-item">
-                                      <span>{link.text} </span>
-                                    </a>
-                                  </div>
-                                )
-                              })}
+                              {chunkLinks(li.links).map((column, colIndex) => (
+                                <div className="dropdown-column" key={colIndex}>
+                                  {column.map((link, index) => (
+                                    <div className="menuitemeffect" key={index}>
+                                      <a href={link.url} className="dropdown-item">
+                                        <span>{link.text} </span>
+                                      </a>
+                                    </div>
+                                  ))}
+                                </div>
+                              ))}
                             </div>
                           </div>
                         </div>

--- a/src/components/NavbarV2.js
+++ b/src/components/NavbarV2.js
@@ -98,9 +98,6 @@ const NavbarV2 = class extends React.Component {
                           </div>
                           <div id="dropdown-menu" role="menu" className="dropdown-menu">
                             <div className="dropdown-content">
-                              <div className="nested-menu-image">
-                                <img src={li.image} alt="" style={li.marginLeft ? { marginLeft: li.marginLeft } : {}} />
-                              </div>
                               {li.links.map((link, index) => {
                                 return (
                                   <div className="menuitemeffect" key={index}>

--- a/src/content/navbar.json
+++ b/src/content/navbar.json
@@ -2,7 +2,6 @@
   "nav": [
     {
       "title": "Projects",
-      "image": "/img/menu/menu_projects.jpg",
       "url": "/projects/",
       "display": true,
       "links": [
@@ -30,8 +29,6 @@
     },
     {
       "title": "Membership",
-      "image": "/img/menu/menu_membership.jpg",
-      "marginLeft": "-408px",
       "display": true,
       "links": [
         {
@@ -54,8 +51,6 @@
     },
     {
       "title": "Events",
-      "image": "/img/home/image3-taller.jpg",
-      "marginLeft": "-346px",
       "url": "/community-events/",
       "display": true,
       "links": [
@@ -87,8 +82,6 @@
     },
     {
       "title": "About",
-      "image": "/img/menu/menu_about.jpg",
-      "marginLeft": "-424px",
       "url": "/about/",
       "display": true,
       "links": [
@@ -120,8 +113,6 @@
     },
     {
       "title": "News",
-      "image": "/img/middle-banner-21.png",
-      "marginLeft": "-423px",
       "display": true,
       "links": [
         {
@@ -140,8 +131,7 @@
     },
     {
       "title": "Jobs",
-      "url": "https://openstack.org/jobs",
-      "image": "/img/background-shapes1.svg"
+      "url": "https://openstack.org/jobs"
     }
   ],
   "button": {

--- a/src/style/modules/_basestructure.scss
+++ b/src/style/modules/_basestructure.scss
@@ -511,7 +511,10 @@ div.content.custom > main > section > div > div > div > h3 {
 
 @media (max-width: 768px) {
   .dropdown {
-    display: block;
+    // flow-root forces this to establish its own block formatting context, so
+    // it reliably contains the expanded .dropdown-menu's height instead of
+    // collapsing to just the trigger's height and letting the next nav item overlap it
+    display: flow-root;
     width: 100%;
 
     .dropdown-trigger {

--- a/src/style/modules/_basestructure.scss
+++ b/src/style/modules/_basestructure.scss
@@ -409,7 +409,6 @@ div.content.custom > main > section > div > div > div > h3 {
     margin-top: 22px;
     font-size: 17px;
     @media (min-width: 769px) {
-      height: 267px;
       padding-bottom: 10%;
       padding-top: 10%;
     }
@@ -469,17 +468,6 @@ div.content.custom > main > section > div > div > div > h3 {
   }
 }
 
-.nested-menu-image {
-  display: none;
-  height: 0px;
-  img {
-    margin-left: -428px;
-    height: 268px;
-    max-width: unset;
-    margin-top: -10%;
-  }
-}
-
 .dropdown.is-active .dropdown-menu,
 .dropdown.is-hoverable:hover .dropdown-menu {
   display: block;
@@ -487,13 +475,6 @@ div.content.custom > main > section > div > div > div > h3 {
   width: auto;
   min-width: 240px;
   border-radius: 0;
-  .nested-menu-image {
-    display: block;
-    @media (max-width: 1024px) {
-      //small screen pantalla
-      display: none;
-    }
-  }
 }
 
 // overwrite bootstrap styles from schedule

--- a/src/style/modules/_basestructure.scss
+++ b/src/style/modules/_basestructure.scss
@@ -408,6 +408,7 @@ div.content.custom > main > section > div > div > div > h3 {
     box-shadow: 0 2px 3px rgba(34, 34, 34, 0.1), 0 0 0 1px rgba(34, 34, 34, 0.1);
     margin-top: 22px;
     font-size: 17px;
+    display: flex;
     @media (min-width: 769px) {
       padding-bottom: 10%;
       padding-top: 10%;
@@ -415,9 +416,21 @@ div.content.custom > main > section > div > div > div > h3 {
     left: 50%;
     @media (max-width: 769px) {
       //small screen pantalla
+      flex-direction: column;
       margin-top: 5px;
       padding-bottom: 1.5rem;
       padding-top: 1.5rem;
+    }
+
+    .dropdown-column + .dropdown-column {
+      margin-left: 20px;
+      padding-left: 20px;
+      border-left: 1px solid rgba(22, 22, 22, 0.1);
+      @media (max-width: 769px) {
+        margin-left: 0;
+        padding-left: 0;
+        border-left: none;
+      }
     }
     a span {
       color: #161616;
@@ -471,10 +484,17 @@ div.content.custom > main > section > div > div > div > h3 {
 .dropdown.is-active .dropdown-menu,
 .dropdown.is-hoverable:hover .dropdown-menu {
   display: block;
-  left: calc(50% - 110px);
+  left: 50%;
+  transform: translateX(-50%);
   width: auto;
   min-width: 240px;
   border-radius: 0;
+  @media (max-width: 769px) {
+    // small screen pantalla: keep dropdown aligned under the full-width trigger
+    transform: none;
+    left: 0;
+    width: 100%;
+  }
 }
 
 // overwrite bootstrap styles from schedule

--- a/src/style/modules/_basestructure.scss
+++ b/src/style/modules/_basestructure.scss
@@ -406,12 +406,14 @@ div.content.custom > main > section > div > div > div > h3 {
     border-radius: 0px;
     box-shadow: none;
     box-shadow: 0 2px 3px rgba(34, 34, 34, 0.1), 0 0 0 1px rgba(34, 34, 34, 0.1);
-    margin-top: 22px;
+    margin-top: 16px;
     font-size: 17px;
     display: flex;
     @media (min-width: 769px) {
-      padding-bottom: 10%;
-      padding-top: 10%;
+      // fixed spacing instead of a percentage, so the panel's vertical
+      // padding doesn't balloon as it widens to fit more columns
+      padding-bottom: 24px;
+      padding-top: 24px;
     }
     left: 50%;
     @media (max-width: 769px) {
@@ -474,25 +476,34 @@ div.content.custom > main > section > div > div > div > h3 {
   }
 
   // dropdown arrow: centered under the top-level nav item itself (not the wide
-  // dropdown panel), sitting on the black nav background just below the trigger
+  // dropdown panel), sitting on the black nav background just below the trigger.
+  // Anchored to .dropdown-trigger (not .dropdown) since the trigger tightly wraps
+  // just the button with no absolutely-positioned siblings, so top: 100% always
+  // lands right at the button's bottom edge regardless of item/height variance.
   .dropdown {
-    &:after {
+    .dropdown-trigger {
+      position: relative;
+    }
+
+    .dropdown-trigger:after {
       content: " ";
       position: absolute;
       top: 100%;
       left: 50%;
       transform: translateX(-50%);
-      margin-top: 5px;
       width: 0;
       height: 0;
       border: 10px solid transparent;
       border-bottom-color: $white;
       pointer-events: none;
+      // .dropdown-menu is Bootstrap's, with z-index: 1000 - the arrow must
+      // exceed that to render above the panel instead of behind it
+      z-index: 1001;
       display: none;
     }
 
-    &.is-active:after,
-    &.is-hoverable:hover:after {
+    &.is-active .dropdown-trigger:after,
+    &.is-hoverable:hover .dropdown-trigger:after {
       display: block;
     }
   }

--- a/src/style/modules/_basestructure.scss
+++ b/src/style/modules/_basestructure.scss
@@ -459,25 +459,6 @@ div.content.custom > main > section > div > div > div > h3 {
       }
     }
 
-    &:after {
-      /* arrow */
-      // bottom: 70%;
-      top: -2px;
-      left: 50%;
-      border: solid transparent;
-      content: " ";
-      height: 0;
-      width: 0;
-      position: absolute;
-      pointer-events: none;
-      border-color: rgba(255, 255, 255, 0);
-      border-bottom-color: $white;
-      border-width: 20px;
-      margin-left: -30px;
-      @media (max-width: 768px) {
-        display: none;
-      }
-    }
   }
 }
 
@@ -485,11 +466,35 @@ div.content.custom > main > section > div > div > div > h3 {
   .dropdown.is-active .dropdown-menu,
   .dropdown.is-hoverable:hover .dropdown-menu {
     display: block;
-    left: 50%;
-    transform: translateX(-50%);
+    left: 0;
+    transform: none;
     width: auto;
     min-width: 240px;
     border-radius: 0;
+  }
+
+  // dropdown arrow: centered under the top-level nav item itself (not the wide
+  // dropdown panel), sitting on the black nav background just below the trigger
+  .dropdown {
+    &:after {
+      content: " ";
+      position: absolute;
+      top: 100%;
+      left: 50%;
+      transform: translateX(-50%);
+      margin-top: 5px;
+      width: 0;
+      height: 0;
+      border: 10px solid transparent;
+      border-bottom-color: $white;
+      pointer-events: none;
+      display: none;
+    }
+
+    &.is-active:after,
+    &.is-hoverable:hover:after {
+      display: block;
+    }
   }
 }
 

--- a/src/style/modules/_basestructure.scss
+++ b/src/style/modules/_basestructure.scss
@@ -481,19 +481,76 @@ div.content.custom > main > section > div > div > div > h3 {
   }
 }
 
-.dropdown.is-active .dropdown-menu,
-.dropdown.is-hoverable:hover .dropdown-menu {
-  display: block;
-  left: 50%;
-  transform: translateX(-50%);
-  width: auto;
-  min-width: 240px;
-  border-radius: 0;
-  @media (max-width: 769px) {
-    // small screen pantalla: keep dropdown aligned under the full-width trigger
-    transform: none;
-    left: 0;
+@media (min-width: 769px) {
+  .dropdown.is-active .dropdown-menu,
+  .dropdown.is-hoverable:hover .dropdown-menu {
+    display: block;
+    left: 50%;
+    transform: translateX(-50%);
+    width: auto;
+    min-width: 240px;
+    border-radius: 0;
+  }
+}
+
+@media (max-width: 768px) {
+  .dropdown {
+    display: block;
     width: 100%;
+
+    .dropdown-trigger {
+      width: 100%;
+
+      .button {
+        width: 100%;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+      }
+    }
+
+    .dropdown-menu {
+      display: none;
+      position: static;
+      transform: none;
+      left: 0;
+      width: 100%;
+    }
+
+    .dropdown-content {
+      position: static;
+      left: 0;
+      transform: none;
+      width: 100%;
+
+      &:after {
+        display: none;
+      }
+    }
+
+    // only .is-active (click) opens the menu on mobile - hover is disabled
+    &.is-active .dropdown-menu {
+      display: block;
+    }
+
+    &.is-hoverable:hover .dropdown-menu {
+      display: none;
+    }
+
+    &.is-hoverable.is-active:hover .dropdown-menu {
+      display: block;
+    }
+  }
+
+  .navbar-dropdown-arrow {
+    margin-left: 10px;
+    font-size: 12px;
+  }
+}
+
+@media (min-width: 769px) {
+  .navbar-dropdown-arrow {
+    display: none;
   }
 }
 

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -35,7 +35,6 @@ collections:
         fields:
           - { label: "Pages", name: "nav", widget: list, fields: [
             { label: "Title", name: "title", widget: string },
-            { label: "Image", name: "image", widget: image },
             { label: "Left Margin", name: "marginLeft", widget: string, required: false },
             { label: "Link", name: "url", widget: string, required: false },
             { label: "Display", name: "display", widget: boolean, required: false },


### PR DESCRIPTION
Updating the main header nav to allow for additional links as needed, removing images and creating a column layout

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Navigation dropdowns now expand on tap in mobile view (desktop remains hover-based).
* **UI Improvements**
  * Dropdown menus render links in multiple columns and update arrow/active indicators based on open state.
  * Improved responsive dropdown panel layout and spacing across breakpoints.
  * Removed decorative image entries from several navigation items; Jobs retains its URL.
* **Configuration**
  * Updated the navigation menu configuration to reflect the removed image fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->